### PR TITLE
Upgrade to Symfony ^4.4 || ^5.0 and upgrade phpunit to 8.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@
 ehthumbs.db
 Icon?
 Thumbs.db
+
+.idea
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+    - 5.5.9
     - 5.6
     - 7.0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-    - 5.5.9
-    - 5.6
-    - 7.0
+    - 7.2
+    - 7.3
+    - 7.4
 
 env:
     matrix:

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "symfony"
     ],
     "require": {
-        "php": "~5.6|~7.0",
+        "php": "5.5.9|~5.6|~7.0",
         "league/tactician": "~1.0",
         "symfony/event-dispatcher": "~2.8|~3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,16 +14,22 @@
         "symfony"
     ],
     "require": {
-        "php": "~5.5.9|~5.6|~7.0",
-        "league/tactician": "~1.0",
-        "symfony/event-dispatcher": "~2.8|~3.0"
+        "php": "^7.2",
+        "league/tactician": "^1.0",
+        "symfony/event-dispatcher": "^4.4 || ^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8"
+        "roave/security-advisories": "dev-master",
+        "phpunit/phpunit": "^8.5"
     },
     "autoload": {
         "psr-4": {
             "Chrisguitarguy\\Tactician\\SymfonyEvents\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Chrisguitarguy\\Tactician\\SymfonyEvents\\Tests\\": "test/"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
         "symfony"
     ],
     "require": {
-        "php": "5.5.9|~5.6|~7.0",
+        "php": "~5.5.9|~5.6|~7.0",
         "league/tactician": "~1.0",
         "symfony/event-dispatcher": "~2.8|~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.0"
+        "phpunit/phpunit": "~4.8"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,9 +8,8 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
-         bootstrap="vendor/autoload.php">
-
+         bootstrap="vendor/autoload.php"
+>
     <testsuites>
         <testsuite name="default">
             <directory suffix="Test.php">test</directory>
@@ -26,5 +25,4 @@
     <logging>
         <log type="coverage-text" target="php://stdout" showUncoveredFiles="true" />
     </logging>
-
 </phpunit>

--- a/src/CommandEvent.php
+++ b/src/CommandEvent.php
@@ -8,7 +8,7 @@
 
 namespace Chrisguitarguy\Tactician\SymfonyEvents;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * ABC for command events. Provides the getter for the command.

--- a/src/CommandEvents.php
+++ b/src/CommandEvents.php
@@ -15,9 +15,9 @@ namespace Chrisguitarguy\Tactician\SymfonyEvents;
  */
 final class CommandEvents
 {
-    const RECEIVED = 'command.received';
-    const HANDLED = 'command.handled';
-    const FAILED = 'command.failed';
+    public const RECEIVED = 'command.received';
+    public const HANDLED = 'command.handled';
+    public const FAILED = 'command.failed';
 
     public static function received($command)
     {
@@ -34,9 +34,9 @@ final class CommandEvents
         return self::eventName(self::FAILED, $command);
     }
 
-    private static function eventName($what, $command)
+    private static function eventName(string $what, $command): string
     {
-        return sprintf('%s.%s', $what, is_object($command) ? get_class($command) : (string) $command);
+        return \sprintf('%s.%s', $what, \is_object($command) ? \get_class($command) : (string) $command);
     }
 
     // @codeCoverageIgnoreStart

--- a/src/CommandFailed.php
+++ b/src/CommandFailed.php
@@ -16,17 +16,17 @@ namespace Chrisguitarguy\Tactician\SymfonyEvents;
 final class CommandFailed extends CommandEvent
 {
     /**
-     * @var Exception
+     * @var \Throwable
      */
     private $exception;
 
-    public function __construct($command, \Exception $exception)
+    public function __construct($command, \Throwable $exception)
     {
         parent::__construct($command);
         $this->exception = $exception;
     }
 
-    public function getException()
+    public function getException(): \Throwable
     {
         return $this->exception;
     }

--- a/src/EventMiddleware.php
+++ b/src/EventMiddleware.php
@@ -43,7 +43,7 @@ final class EventMiddleware implements Middleware
             $this->dispatch(CommandEvents::handled($command), new CommandHandled($command, $result));
 
             return $result;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->dispatch(CommandEvents::FAILED, new CommandFailed($command, $e));
             $this->dispatch(CommandEvents::failed($command), new CommandFailed($command, $e));
 
@@ -51,8 +51,8 @@ final class EventMiddleware implements Middleware
         }
     }
 
-    private function dispatch($eventName, CommandEvent $event)
+    private function dispatch($eventName, CommandEvent $event): void
     {
-        $this->dispatcher->dispatch($eventName, $event);
+        $this->dispatcher->dispatch($event, $eventName);
     }
 }


### PR DESCRIPTION
This is a sync with our fork which has been used in production extensively over the past years. It adds compatibility with Symfony 4.4. and 5.0.

As it drops support for PHP 5.6 my suggestion would be to release it as a new major.